### PR TITLE
Date picker background fix

### DIFF
--- a/Asam/AsamSearch.m
+++ b/Asam/AsamSearch.m
@@ -191,6 +191,7 @@
     self.subRegionsPickerView = [[UIPickerView alloc] initWithFrame:CGRectMake(0, toolbarHeight, 0, 0)];
 	self.subRegionsPickerView.delegate = self;
 	self.subRegionsPickerView.dataSource = self;
+    self.subRegionsPickerView.backgroundColor = [UIColor whiteColor];
 	self.subRegionsPickerView.showsSelectionIndicator = YES;
     
     UIToolbar *pickerToolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, toolbarHeight)];


### PR DESCRIPTION
Modified the background of the from and to date pickers on the ASAM Query popover to fix a bug causing the date picker to be see through on iOS 7.1
