### PR TITLE
Fixed bug in REVClusterManager.m

### DIFF
--- a/Asam/LegalViewController_ipad.m
+++ b/Asam/LegalViewController_ipad.m
@@ -29,7 +29,7 @@
     }
     self.navigationController.navigationBar.translucent = NO;
     self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:navigationTitle style:UIBarButtonItemStylePlain target:nil action:nil];
-        
+    
     self.legalTitleArray = @[@"REVClusterMap", @"Reachability", @"DSActivityView", @"DDActionHeaderView", @"Natural Earth"];
     self.legalFileArray = @[@"revclustermap", @"reachability", @"dsactivityview", @"ddactionheaderview", @"naturalearth"];
     

--- a/Asam/REVClusterManager.m
+++ b/Asam/REVClusterManager.m
@@ -79,8 +79,12 @@
         int localTileNumberY = floor( localPointY / tileHeight );
         int localTileNumber = localTileNumberX + (localTileNumberY * (BLOCKS+1));
         
-        [(REVClusterBlock *)[clusteredBlocks objectAtIndex:localTileNumber] addAnnotation:pin];
-
+        if(localTileNumber >= 0 && localTileNumber < [clusteredBlocks count]) {
+            [(REVClusterBlock *)[clusteredBlocks objectAtIndex:localTileNumber] addAnnotation:pin];
+        }
+        else {
+            NSLog(@"Incorrect localTileNumber calculated.  Ignoring cluster.");
+        }
         
     }
     


### PR DESCRIPTION
...that was causing the Offline Map-View to crash the the iPad during some panning/zooming activities.  Discovered by chance after testing out the new legal text added for the Natural Earth data.

Minor cleanup to LegalViewController.
