### PR TITLE
Changed reset button on the MainView to a 'strong' reference (previously...

### DIFF
--- a/Asam/MainView.m
+++ b/Asam/MainView.m
@@ -45,7 +45,7 @@
 @property (nonatomic, strong) IBOutlet UILabel *asamTotalLabel;
 @property (nonatomic, strong) IBOutlet UILabel *asamLabelDisplayed;
 @property (nonatomic, strong) AsamUtility *asamUtil;
-@property (nonatomic, weak) UIButton *restartButton;
+@property (nonatomic, strong) UIButton *restartButton;
 
 - (IBAction)showAsamList:(id)sender;
 - (IBAction)asamSearchView:(id)sender;
@@ -481,6 +481,7 @@
     self.asamSearchPopOver = nil;
     self.asamSearchView = nil;
     self.displayAsamInListArray = nil;
+    self.restartButton = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [super viewDidUnload];
 }


### PR DESCRIPTION
... a 'weak').  On the newest / fastest iPads, the weak reference was getting dalloc'ed before the control was even added to the screen.

This fixes the insta-crash I the iPad Air.
