### PR TITLE
iOS 8 fixes

### DIFF
--- a/Asam.xcodeproj/project.pbxproj
+++ b/Asam.xcodeproj/project.pbxproj
@@ -961,7 +961,7 @@
 				LastUpgradeCheck = 0510;
 				TargetAttributes = {
 					24C78D4B14D5B35E0027AE3B = {
-						DevelopmentTeam = PDRAS7XQ3Y;
+						DevelopmentTeam = A8EK924J35;
 					};
 				};
 			};

--- a/Asam/AboutAsam_iphone.m
+++ b/Asam/AboutAsam_iphone.m
@@ -32,7 +32,7 @@
     [super viewDidLoad];
     if ([self respondsToSelector:@selector(setEdgesForExtendedLayout:)]) { // iOS 7+
         self.edgesForExtendedLayout = UIRectEdgeNone;
-        self.navigationController.navigationBar.barTintColor = [UIColor colorWithRed:0.1f green:0.1f blue:0.1f alpha:1.0f];
+        self.navigationController.navigationBar.barTintColor = [UIColor blackColor];
         self.navigationController.navigationBar.titleTextAttributes = [NSDictionary dictionaryWithObject:[UIColor whiteColor] forKey:UITextAttributeTextColor];
     }
     self.wordingLabel.text = @"Anti-Shipping Activity Messages (ASAM) include the locations and descriptive accounts of specific hostile acts against ships and mariners. The reports may be useful for recognition, prevention and avoidance of potential hostile activity.";

--- a/Asam/AsamDetailView.m
+++ b/Asam/AsamDetailView.m
@@ -167,7 +167,6 @@
 
 - (void)setUpBarTitle {
     if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1) { // iOS 7+
-        self.navigationController.navigationBar.backgroundColor = [UIColor colorWithWhite:(64/255.0f) alpha:1.0f];
         self.tableView.backgroundColor = [UIColor blackColor];
     }
     else {
@@ -175,6 +174,22 @@
         [backImage setFrame:self.tableView.frame];
         self.tableView.backgroundView = backImage;
     }
+    
+//    self.tableView.backgroundColor = [UIColor colorWithWhite:(64/255.0f) alpha:1.0f];
+//    if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1) { // iOS 7+
+//        [self.navigationController.navigationBar setBackgroundImage:[UIImage new]
+//                                                      forBarMetrics:UIBarMetricsDefault];
+//        self.navigationController.navigationBar.shadowImage = [UIImage new];
+//        self.navigationController.navigationBar.translucent = YES;
+//        self.navigationController.view.backgroundColor = [UIColor clearColor];
+//    }
+//    else {
+//        UIImageView *backImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"background"]];
+//        [backImage setFrame:self.tableView.frame];
+//        self.tableView.backgroundView = backImage;
+//    }
+    
+    
     self.asamUtil = [[AsamUtility alloc] init];
     UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 120, 30)];
     titleLabel.font = [UIFont fontWithName:@"Helvetica-Bold" size:16.0];

--- a/Asam/AsamListView.m
+++ b/Asam/AsamListView.m
@@ -13,7 +13,7 @@
 @property (nonatomic, strong) IBOutlet UITableView *tableView;
 @property (nonatomic, strong) AsamUtility *asamUtil;
 
-- (void)showActionSheet;
+- (void)showActionSheet:(id) sender;
 - (void)prepareNavBar;
 - (void)sortAsamArrayWithVictimQualifier;
 - (void)sortAsamArrayWithAggressorQualifier;
@@ -117,7 +117,7 @@ static NSString *CellClassName = @"AsamCustomCell";
                        initWithTitle:@"Sort"
                        style:UIBarButtonItemStylePlain
                        target:self
-                       action:@selector(showActionSheet)];
+                        action:@selector(showActionSheet:)];
     
     self.navigationItem.rightBarButtonItem = listButton;
     
@@ -131,13 +131,11 @@ static NSString *CellClassName = @"AsamCustomCell";
     
     self.tableView.separatorColor = [UIColor whiteColor];
     if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1) { // iOS 7+
-        self.tableView.backgroundColor = [UIColor colorWithWhite:(64/255.0f) alpha:1.0f];
-        [self.navigationController.navigationBar setBackgroundImage:[UIImage new]
-                                                      forBarMetrics:UIBarMetricsDefault];
-        self.navigationController.navigationBar.shadowImage = [UIImage new];
-        self.navigationController.navigationBar.translucent = YES;
-        self.navigationController.view.backgroundColor = [UIColor clearColor];
+        self.tableView.backgroundColor = [UIColor blackColor];
         self.navigationController.navigationBar.tintColor = [UIColor whiteColor];
+        self.navigationController.navigationBar.barStyle = UIBarStyleBlackTranslucent;
+        self.navigationController.navigationBar.barTintColor = [UIColor colorWithWhite:(64/255.0f) alpha:1.0f];
+        self.navigationController.navigationBar.translucent = NO;
     }
     else {
         UIImageView *backImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"background"]];
@@ -156,7 +154,7 @@ static NSString *CellClassName = @"AsamCustomCell";
 
 #pragma 
 #pragma mark - Private methods (UIActionSheet) impl.
-- (void)showActionSheet {
+- (void)showActionSheet:(id) sender {
     UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:@"Sort By:" delegate:self cancelButtonTitle:@"Cancel" destructiveButtonTitle:nil otherButtonTitles:@"Victim", @"Aggressor", @"Date Ascending", @"Date Descending", nil];
     [actionSheet showInView:self.view];
 }

--- a/Asam/AsamListViewController_iphone.m
+++ b/Asam/AsamListViewController_iphone.m
@@ -124,20 +124,14 @@ static NSString *CellClassName = @"AsamCustomCell";
     backButton.tintColor = [UIColor blackColor];
     self.navigationItem.backBarButtonItem = backButton;
 
-    UISegmentedControl *segmentedControl = [[UISegmentedControl alloc] initWithItems:@[@"Sort"]];
-    segmentedControl.frame = CGRectMake(0, 0, 100, 30);
-    segmentedControl.tag = 0;
-    [segmentedControl addTarget:self action:@selector(segmentAction:) forControlEvents:UIControlEventValueChanged];
-    segmentedControl.segmentedControlStyle = UISegmentedControlStyleBar;
-    segmentedControl.momentary = YES;
-    [segmentedControl sizeToFit];
-    segmentedControl.tintColor = [UIColor blackColor];
-    if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1) { // iOS 7+
-        [segmentedControl setTitleTextAttributes:@{NSForegroundColorAttributeName:[UIColor whiteColor]} forState:UIControlStateNormal];
-    }
     
-    UIBarButtonItem *segmentBarItem = [[UIBarButtonItem alloc] initWithCustomView:segmentedControl];
-    self.navigationItem.rightBarButtonItem = segmentBarItem;
+    UIBarButtonItem *sortButton = [[UIBarButtonItem alloc]
+                                   initWithTitle:@"Sort"
+                                   style:UIBarButtonItemStylePlain
+                                   target:self
+                                   action:@selector(showActionSheet)];
+    
+    self.navigationItem.rightBarButtonItem = sortButton;
     
     UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 0, 320, 40)];
     titleLabel.font = [UIFont fontWithName:@"Helvetica-Bold" size:16.0];
@@ -148,23 +142,11 @@ static NSString *CellClassName = @"AsamCustomCell";
     self.navigationItem.titleView = titleLabel;
 }
 
-- (void)segmentAction:(UISegmentedControl*)sender {
-    switch ([sender selectedSegmentIndex]) {
-        case 0:
-            [self showActionSheet];
-            break;
-            
-        default:
-            break;
-    }
-}
-
 #pragma
 #pragma mark - Private methods (UIActionSheet) impl.
 - (IBAction)showActionSheet {
     UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:@"Sort By:" delegate:self cancelButtonTitle:@"Cancel" destructiveButtonTitle:nil otherButtonTitles:@"Victim", @"Aggressor", @"Date Ascending", @"Date Descending", nil];
     [actionSheet showInView:self.view];
-    
 }
 
 - (void)actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex {

--- a/Asam/AsamMap_iphone.m
+++ b/Asam/AsamMap_iphone.m
@@ -86,6 +86,12 @@
     [super viewDidAppear:animated];
 }
 
+-(void) viewWillAppear:(BOOL)animated {
+    self.navigationController.navigationBarHidden = NO;
+    
+    [super viewWillAppear:animated];
+}
+
 - (void)viewDidUnload {
     [super viewDidUnload];
     self.mapView = nil;

--- a/Asam/AsamSearch.m
+++ b/Asam/AsamSearch.m
@@ -47,7 +47,6 @@
 #pragma mark
 #pragma mark - Life cycle
 - (void)viewDidLoad {
-    [super viewDidLoad];
     [self setUpBarTitle];
     [self loadSubregions];
     [self.searchButton addBackgroundToButton:self.searchButton];
@@ -56,6 +55,8 @@
     [self createDateFromView];
     [self createDateToView];
     [self createSubRegionView];
+    [super viewDidLoad];
+
 }
 
 - (void)viewDidUnload {
@@ -103,7 +104,6 @@
 - (void) createDateFromView {
     self.datePickerFromView = [[UIDatePicker alloc] init];
     [self.datePickerFromView sizeToFit];
-    self.datePickerFromView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     self.datePickerFromView.backgroundColor = [UIColor whiteColor];
     self.datePickerFromView.date = [NSDate date];
 
@@ -138,7 +138,6 @@
 - (void ) createDateToView {
     self.datePickerToView = [[UIDatePicker alloc] init];
     [self.datePickerToView sizeToFit];
-    self.datePickerToView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     self.datePickerToView.backgroundColor = [UIColor whiteColor];
     self.datePickerToView.date = [NSDate date];
     
@@ -308,11 +307,9 @@
     self.navigationItem.titleView = titleLabel;
     
     if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1) { // iOS 7+
-        [self.navigationController.navigationBar setBackgroundImage:[UIImage new]
-                                                      forBarMetrics:UIBarMetricsDefault];
-        self.navigationController.navigationBar.shadowImage = [UIImage new];
-        self.navigationController.navigationBar.translucent = YES;
-        self.navigationController.view.backgroundColor = [UIColor clearColor];
+        self.navigationController.navigationBar.barStyle = UIBarStyleBlackTranslucent;
+        self.navigationController.navigationBar.barTintColor = [UIColor colorWithWhite:(64/255.0f) alpha:1.0f];
+        self.navigationController.navigationBar.translucent = NO;
     }
     else {
         UIImageView *backImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"background"]];

--- a/Asam/CommonViewController.m
+++ b/Asam/CommonViewController.m
@@ -50,11 +50,6 @@
     self.tableView.separatorColor = [UIColor whiteColor];
     if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1) { // iOS 7+
         self.tableView.backgroundColor = [UIColor blackColor];
-        [self.navigationController.navigationBar setBackgroundImage:[UIImage new]
-                                                      forBarMetrics:UIBarMetricsDefault];
-        self.navigationController.navigationBar.shadowImage = [UIImage new];
-        self.navigationController.navigationBar.translucent = YES;
-        self.navigationController.view.backgroundColor = [UIColor clearColor];
     }
     else {
         UIImageView *backImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"background"]];

--- a/Asam/DisclaimerViewController_iphone.m
+++ b/Asam/DisclaimerViewController_iphone.m
@@ -19,6 +19,8 @@
     if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1) { // iOS 7+
         self.disclaimerTextView.backgroundColor = [UIColor blackColor];
         self.toolBar.tintColor = [UIColor whiteColor];
+        self.navigationController.navigationBar.translucent = NO;
+        self.navigationController.navigationBar.barTintColor = [UIColor orangeColor];
         [self performSelector:@selector(setNeedsStatusBarAppearanceUpdate)];
     }
     else {
@@ -48,6 +50,11 @@
 
 -(BOOL)prefersStatusBarHidden {
     return YES;
+}
+
+- (UIBarPosition)positionForBar:(id <UIBarPositioning>)bar {
+    
+    return UIBarPositionTopAttached;
 }
 
 @end

--- a/Asam/DisclaimerViewController_iphone.xib
+++ b/Asam/DisclaimerViewController_iphone.xib
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="5056" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" variant="6xAndEarlier" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6249" systemVersion="13F34" targetRuntime="iOS.CocoaTouch" variant="6xAndEarlier" propertyAccessControl="none">
     <dependencies>
-        <deployment defaultVersion="1552" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6243"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="DisclaimerViewController_iphone">
             <connections>
                 <outlet property="disclaimerTextView" destination="13" id="14"/>
-                <outlet property="statusBarBackground" destination="hFR-kb-j8N" id="Vnl-hF-Ddi"/>
                 <outlet property="toolBar" destination="4" id="6"/>
                 <outlet property="topTollBar" destination="9" id="11"/>
                 <outlet property="view" destination="1" id="3"/>
@@ -43,7 +42,7 @@
                 <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" barStyle="black" translucent="NO" id="9">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                    <color key="backgroundColor" white="0.0" alpha="0.80000000000000004" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                     <inset key="insetFor6xAndEarlier" minX="0.0" minY="20" maxX="0.0" maxY="-20"/>
                     <items>
                         <barButtonItem style="plain" systemItem="flexibleSpace" id="1gI-vJ-r2F"/>
@@ -60,26 +59,28 @@
                         <barButtonItem style="plain" systemItem="flexibleSpace" id="Tsc-9l-f0v"/>
                     </items>
                     <color key="barTintColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                    <connections>
+                        <outlet property="delegate" destination="-1" id="PX0-yH-gT1"/>
+                    </connections>
                 </toolbar>
                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" indicatorStyle="white" delaysContentTouches="NO" editable="NO" id="13">
-                    <rect key="frame" x="0.0" y="64" width="320" height="352"/>
+                    <rect key="frame" x="8" y="64" width="304" height="352"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                    <mutableString key="text">Information contained in this Application resides on a computer system funded by the National Geospatial-Intelligence Agency. This system and related equipment are intended for the communication, transmission, processing and storage of U.S. Government information. With respect to information available in this Application, neither the United States Government nor the National Geospatial-Intelligence Agency nor any of their employees, makes any warranty, express or implied, including the warranties of merchantability and fitness for a particular purpose, or assumes any legal liability or responsibility for the accuracy, completeness, or usefulness of any information, apparatus, product, or process disclosed, or represents that its use would not infringe privately owned rights.
+                    <string key="text">Information contained in this Application resides on a computer system funded by the National Geospatial-Intelligence Agency. This system and related equipment are intended for the communication, transmission, processing and storage of U.S. Government information. With respect to information available in this Application, neither the United States Government nor the National Geospatial-Intelligence Agency nor any of their employees, makes any warranty, express or implied, including the warranties of merchantability and fitness for a particular purpose, or assumes any legal liability or responsibility for the accuracy, completeness, or usefulness of any information, apparatus, product, or process disclosed, or represents that its use would not infringe privately owned rights.
 
-</mutableString>
+</string>
                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="15"/>
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                 </textView>
-                <view contentMode="scaleToFill" id="hFR-kb-j8N">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="20"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
-                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.80000000000000004" colorSpace="calibratedRGB"/>
-                    <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
-                </view>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
         </view>
     </objects>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4"/>
+    </simulatedMetricsContainer>
 </document>

--- a/Asam/LegalViewController_iphone.m
+++ b/Asam/LegalViewController_iphone.m
@@ -111,7 +111,8 @@
 - (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section {
     if ([view isKindOfClass:[UITableViewHeaderFooterView class]]) {
         UITableViewHeaderFooterView *tableViewHeaderFooterView = (UITableViewHeaderFooterView *)view;
-        tableViewHeaderFooterView.textLabel.font = [UIFont fontWithName:@"HelveticaNeue-Bold" size:16.0];
+        tableViewHeaderFooterView.textLabel.font = [UIFont fontWithDescriptor:[UIFontDescriptor fontDescriptorWithFontAttributes:@{@"NSCTFontUIUsageAttribute" : UIFontTextStyleBody,
+                                                                                                                @"NSFontNameAttribute" : @"tableViewHeaderFooterView"}] size:16.0];
         tableViewHeaderFooterView.textLabel.shadowOffset = CGSizeMake(0.0, 0.0);
         tableViewHeaderFooterView.textLabel.textColor = [UIColor whiteColor];
     }

--- a/Asam/MainView.m
+++ b/Asam/MainView.m
@@ -82,6 +82,10 @@
     
     if (![self.asamListPopOver isPopoverVisible]) {
 		AsamListView *asamListView = [[AsamListView alloc] initWithNibName:@"AsamListView" bundle:nil];
+        NSSortDescriptor *dateDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"dateofOccurrence" ascending:NO selector:@selector(compare:)];
+        NSArray *sortDescriptors = @[dateDescriptor];
+        asamListView.asamArray = [self.displayAsamInListArray sortedArrayUsingDescriptors:sortDescriptors];
+
         UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:asamListView];
 
 		self.asamListPopOver = [[UIPopoverController alloc] initWithContentViewController:navController];
@@ -91,14 +95,19 @@
             self.asamListPopOver.backgroundColor = [UIColor colorWithWhite:(64/255.0f) alpha:1.0f];
             navController.navigationBar.tintColor = [UIColor whiteColor];
         }
-        
-        [self.asamListPopOver presentPopoverFromBarButtonItem:sender permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
         self.asamListPopOver.delegate = self;
         
-        NSSortDescriptor *dateDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"dateofOccurrence" ascending:NO selector:@selector(compare:)];
-        NSArray *sortDescriptors = @[dateDescriptor];
-        asamListView.asamArray = [self.displayAsamInListArray sortedArrayUsingDescriptors:sortDescriptors];
+        if ([navController respondsToSelector:@selector(setPreferredContentSize:)]) {
+            [navController setPreferredContentSize:CGSizeMake(320.0f, 500.0f)];
+        }
+        else {
+            self.asamListView.contentSizeForViewInPopover = CGSizeMake(320.0f, 500.0f);
+        }
+
         [self.navigationController pushViewController:asamListView animated:YES];
+        
+        [self.asamListPopOver presentPopoverFromBarButtonItem:sender permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+
 	}
     else {
 		[self.asamListPopOver dismissPopoverAnimated:YES];
@@ -125,6 +134,9 @@
             self.asamSettingsView.edgesForExtendedLayout = UIRectEdgeNone;
             self.settingsPopOver.backgroundColor = [UIColor colorWithWhite:(64/255.0f) alpha:1.0f];
             self.settingsPopOver.popoverContentSize = CGSizeMake(400.0f, 235.0f);
+            navController.navigationBar.barStyle = UIBarStyleBlackTranslucent;
+            navController.navigationBar.barTintColor = [UIColor colorWithWhite:(64/255.0f) alpha:1.0f];
+            navController.navigationBar.translucent = NO;
             navController.navigationBar.tintColor = [UIColor whiteColor];
         }
         else {
@@ -598,19 +610,27 @@
 
     if (selectedObject.nodeCount > 1) {
         AsamListView *asamListView = [[AsamListView alloc] initWithNibName:@"AsamListView" bundle:nil];
+        NSSortDescriptor *dateDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"dateofOccurrence" ascending:NO selector:@selector(compare:)];
+        NSArray *sortDescriptors = @[dateDescriptor];
+        
+        asamListView.asamArray = [selectedObject.nodes sortedArrayUsingDescriptors:sortDescriptors];
         UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:asamListView];
         self.asamListPopOver = [[UIPopoverController alloc] initWithContentViewController:navController];
         if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1) { // iOS 7+
             self.asamListPopOver.backgroundColor = [UIColor blackColor];
         }
-        self.asamListPopOver.popoverContentSize = CGSizeMake(320.0f, 400.0f);
-        [self.asamListPopOver presentPopoverFromRect:view.bounds inView:view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+        
+        if ([navController respondsToSelector:@selector(setPreferredContentSize:)]) {
+            [navController setPreferredContentSize:CGSizeMake(320.0f, 500.0f)];
+        }
+        else {
+            self.asamListView.contentSizeForViewInPopover = CGSizeMake(320.0f, 500.0f);
+        }
 
         self.asamListPopOver.delegate = self;
-        NSSortDescriptor *dateDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"dateofOccurrence" ascending:NO selector:@selector(compare:)];
-        NSArray *sortDescriptors = @[dateDescriptor];
-        asamListView.asamArray = [selectedObject.nodes sortedArrayUsingDescriptors:sortDescriptors];
+
         [self.navigationController pushViewController:asamListView animated:YES];
+        [self.asamListPopOver presentPopoverFromRect:view.bounds inView:view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
     } else {
         AsamDetailView *asamDetail = [[AsamDetailView alloc] initWithNibName:@"AsamDetailView" bundle:nil];
         asamDetail.asam = selectedObject;
@@ -619,14 +639,15 @@
         self.callOutPopOver = [[UIPopoverController alloc] initWithContentViewController:navController];
         if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1) { // iOS 7+
             self.callOutPopOver.backgroundColor = [UIColor blackColor];
+            navController.navigationBar.barStyle = UIBarStyleBlackTranslucent;
+            navController.navigationBar.barTintColor = [UIColor colorWithWhite:(64/255.0f) alpha:1.0f];
+            navController.navigationBar.translucent = NO;
         }
         
         self.callOutPopOver.delegate = self;
         self.callOutPopOver.popoverContentSize = CGSizeMake(320.0f, 400.0f);
         [self.callOutPopOver presentPopoverFromRect:view.bounds inView:view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
-
     }
-
 }
 
 #pragma

--- a/Asam/MainViewController_iphone.m
+++ b/Asam/MainViewController_iphone.m
@@ -113,7 +113,6 @@
 - (IBAction)aboutAssam:(id)sender {
     AboutAsam_iphone *aboutAssam = [[AboutAsam_iphone alloc] initWithNibName:nil bundle:nil];
     UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:aboutAssam];
-    nav.modalTransitionStyle = UIModalTransitionStyleFlipHorizontal;
     [self presentViewController:nav animated:YES completion:nil];
 }
 


### PR DESCRIPTION
List sort action picker did not work on iOS 8 ipad when trying to sort from ASAM list view.
List view delete on ipad was not being passed the ASAM array before init.  This was causing problems with the number of ASAMs title in the list view header.
Sort button on list view on phone was really small.  Changed from a segmented button to a toolbar bar to match the rest of the buttons.
Fixed a bounce in the header title when returning from an ASAM detail view to the ASAM list view on the ipad.
Navbar/header color was wrong in a couple places in ipad, settings popover, list popover, and asam map icon popovers.  Updated this to match the dark grey used across the app.
App crashed when clicking on 'Legal Information' in the about section on iPhone iOS8.  Fixed a problem with setting font on that table view.
