### PR TITLE
Date picker mode should be date.

### DIFF
--- a/Asam/AsamSearch.m
+++ b/Asam/AsamSearch.m
@@ -103,6 +103,7 @@
 #pragma mark - Date From
 - (void) createDateFromView {
     self.datePickerFromView = [[UIDatePicker alloc] init];
+    self.datePickerFromView.datePickerMode = UIDatePickerModeDate;
     [self.datePickerFromView sizeToFit];
     self.datePickerFromView.backgroundColor = [UIColor whiteColor];
     self.datePickerFromView.date = [NSDate date];
@@ -137,6 +138,7 @@
 #pragma mark - Date To
 - (void ) createDateToView {
     self.datePickerToView = [[UIDatePicker alloc] init];
+    self.datePickerToView.datePickerMode = UIDatePickerModeDate;
     [self.datePickerToView sizeToFit];
     self.datePickerToView.backgroundColor = [UIColor whiteColor];
     self.datePickerToView.date = [NSDate date];

--- a/Asam/AsamSearchViewController_iphone.m
+++ b/Asam/AsamSearchViewController_iphone.m
@@ -89,6 +89,7 @@
 
 - (void) createDateFromView {
     self.datePickerFromView = [[UIDatePicker alloc] init];
+    self.datePickerFromView.datePickerMode = UIDatePickerModeDate;
     [self.datePickerFromView sizeToFit];
     self.datePickerFromView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     self.datePickerFromView.backgroundColor = [UIColor whiteColor];
@@ -124,6 +125,7 @@
 - (void)createDateToView {
     
     self.datePickerToView = [[UIDatePicker alloc] init];
+    self.datePickerToView.datePickerMode = UIDatePickerModeDate;
     [self.datePickerToView sizeToFit];
     self.datePickerToView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     self.datePickerToView.backgroundColor = [UIColor whiteColor];


### PR DESCRIPTION
The date picker for iPad and iPhone to/from date on query view should be set to date mode, not date time mode.  Date time mode does not allow you to set a year.
